### PR TITLE
Feature/custom routes middleware and max_size fix

### DIFF
--- a/crates/forge-core/src/config/mod.rs
+++ b/crates/forge-core/src/config/mod.rs
@@ -88,7 +88,14 @@ impl ForgeConfig {
         self.database.validate()?;
         self.auth.validate()?;
         self.mcp.validate()?;
-        self.gateway.max_body_size_bytes()?;
+        let body_limit = self.gateway.max_body_size_bytes()?;
+        let file_limit = self.gateway.max_file_size_bytes()?;
+        if file_limit > body_limit {
+            return Err(ForgeError::Config(format!(
+                "gateway.max_file_size ({}) cannot exceed gateway.max_body_size ({})",
+                self.gateway.max_file_size, self.gateway.max_body_size
+            )));
+        }
 
         // Cross-field: OAuth requires jwt_secret for signing tokens
         if self.mcp.oauth && self.auth.jwt_secret.is_none() {
@@ -243,6 +250,13 @@ pub struct GatewayConfig {
     /// Maximum request body size (e.g. "100mb", "1gb"). Defaults to "20mb".
     #[serde(default = "default_max_body_size")]
     pub max_body_size: String,
+
+    /// Default per-file cap for multipart uploads (e.g. "10mb", "200mb").
+    /// Applies when a mutation does not declare its own `max_size`. Set to
+    /// the same value as `max_body_size` to disable the per-file guard.
+    /// Defaults to "10mb".
+    #[serde(default = "default_max_file_size")]
+    pub max_file_size: String,
 }
 
 impl Default for GatewayConfig {
@@ -257,6 +271,7 @@ impl Default for GatewayConfig {
             cors_origins: default_cors_origins(),
             quiet_routes: default_quiet_routes(),
             max_body_size: default_max_body_size(),
+            max_file_size: default_max_file_size(),
         }
     }
 }
@@ -268,6 +283,16 @@ impl GatewayConfig {
             crate::ForgeError::Config(format!(
                 "invalid gateway.max_body_size '{}'. Expected a size like '20mb', '1gb', or '1048576'",
                 self.max_body_size
+            ))
+        })
+    }
+
+    /// Parse `max_file_size` into bytes.
+    pub fn max_file_size_bytes(&self) -> crate::Result<usize> {
+        crate::util::parse_size(&self.max_file_size).ok_or_else(|| {
+            crate::ForgeError::Config(format!(
+                "invalid gateway.max_file_size '{}'. Expected a size like '10mb', '200mb', or '1048576'",
+                self.max_file_size
             ))
         })
     }
@@ -314,6 +339,10 @@ fn default_quiet_routes() -> Vec<String> {
 
 fn default_max_body_size() -> String {
     "20mb".to_string()
+}
+
+fn default_max_file_size() -> String {
+    "10mb".to_string()
 }
 
 /// Function execution configuration.
@@ -1144,6 +1173,48 @@ mod tests {
             ..Default::default()
         };
         assert!(gw.max_body_size_bytes().is_err());
+    }
+
+    #[test]
+    fn test_max_file_size_defaults() {
+        let gw = GatewayConfig::default();
+        assert_eq!(gw.max_file_size_bytes().unwrap(), 10 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_max_file_size_custom() {
+        let gw = GatewayConfig {
+            max_file_size: "200mb".into(),
+            max_body_size: "500mb".into(),
+            ..Default::default()
+        };
+        assert_eq!(gw.max_file_size_bytes().unwrap(), 200 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_max_file_size_invalid_errors() {
+        let gw = GatewayConfig {
+            max_file_size: "nope".into(),
+            ..Default::default()
+        };
+        assert!(gw.max_file_size_bytes().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_file_larger_than_body() {
+        let toml = r#"
+            [database]
+            url = "postgres://localhost/test"
+
+            [gateway]
+            max_body_size = "10mb"
+            max_file_size = "20mb"
+        "#;
+        let err = ForgeConfig::parse_toml(toml).unwrap_err().to_string();
+        assert!(
+            err.contains("max_file_size"),
+            "Expected max_file_size error, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/forge-runtime/src/gateway/multipart.rs
+++ b/crates/forge-runtime/src/gateway/multipart.rs
@@ -17,9 +17,31 @@ const MAX_JSON_FIELD_SIZE: usize = 1024 * 1024;
 const JSON_FIELD_NAME: &str = "_json";
 
 /// Configurable limits for multipart uploads, injected via Axum extension.
+///
+/// `max_body_size_bytes` caps the total request body when a mutation does
+/// not declare its own `max_size`. `max_file_size_bytes` caps any single
+/// file under the same conditions; per-mutation `max_size` overrides both
+/// (it is treated as an explicit opt-in for large single files).
 #[derive(Debug, Clone)]
 pub struct MultipartConfig {
     pub max_body_size_bytes: usize,
+    pub max_file_size_bytes: usize,
+}
+
+/// Resolve the effective (total, per-file) upload limits for a request.
+///
+/// When a mutation declares `max_size`, the value acts as an explicit
+/// opt-in: it caps both the total body and any single file. Without an
+/// override, the total falls back to `max_body_size_bytes` and any single
+/// file is capped by `max_file_size_bytes` (clamped to the total).
+fn resolve_upload_limits(per_mutation: Option<usize>, config: &MultipartConfig) -> (usize, usize) {
+    match per_mutation {
+        Some(limit) => (limit, limit),
+        None => (
+            config.max_body_size_bytes,
+            config.max_file_size_bytes.min(config.max_body_size_bytes),
+        ),
+    }
 }
 
 /// Create a multipart error response.
@@ -62,12 +84,10 @@ pub async fn rpc_multipart_handler(
         );
     }
 
-    // Per-function limit takes priority, then global config.
-    let max_total = handler
+    let per_mutation = handler
         .function_info(&function)
-        .and_then(|info| info.max_upload_size_bytes)
-        .unwrap_or(mp_config.max_body_size_bytes);
-    let max_file = max_total;
+        .and_then(|info| info.max_upload_size_bytes);
+    let (max_total, max_file) = resolve_upload_limits(per_mutation, &mp_config);
 
     let mut json_args: Option<serde_json::Value> = None;
     let mut uploads: HashMap<String, Upload> = HashMap::new();
@@ -308,11 +328,53 @@ pub async fn rpc_multipart_handler(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    fn config(body: usize, file: usize) -> MultipartConfig {
+        MultipartConfig {
+            max_body_size_bytes: body,
+            max_file_size_bytes: file,
+        }
+    }
 
     #[test]
     fn test_json_field_name_constant() {
         assert_eq!(JSON_FIELD_NAME, "_json");
     }
+
+    #[test]
+    fn per_mutation_limit_overrides_both_total_and_file() {
+        let cfg = config(20 * MB, 10 * MB);
+        let (total, file) = resolve_upload_limits(Some(200 * MB), &cfg);
+        assert_eq!(total, 200 * MB);
+        assert_eq!(file, 200 * MB);
+    }
+
+    #[test]
+    fn without_override_uses_global_body_and_file_limits() {
+        let cfg = config(50 * MB, 10 * MB);
+        let (total, file) = resolve_upload_limits(None, &cfg);
+        assert_eq!(total, 50 * MB);
+        assert_eq!(file, 10 * MB);
+    }
+
+    #[test]
+    fn file_limit_clamped_to_body_limit() {
+        let cfg = config(5 * MB, 50 * MB);
+        let (total, file) = resolve_upload_limits(None, &cfg);
+        assert_eq!(total, 5 * MB);
+        assert_eq!(file, 5 * MB);
+    }
+
+    #[test]
+    fn zero_per_mutation_is_still_respected() {
+        let cfg = config(20 * MB, 10 * MB);
+        let (total, file) = resolve_upload_limits(Some(0), &cfg);
+        assert_eq!(total, 0);
+        assert_eq!(file, 0);
+    }
+
+    const MB: usize = 1024 * 1024;
 }

--- a/crates/forge-runtime/src/gateway/multipart.rs
+++ b/crates/forge-runtime/src/gateway/multipart.rs
@@ -14,9 +14,6 @@ use super::rpc::RpcHandler;
 const MAX_UPLOAD_FIELDS: usize = 20;
 const MAX_FIELD_NAME_LENGTH: usize = 255;
 const MAX_JSON_FIELD_SIZE: usize = 1024 * 1024;
-/// Per-file limit: 10 MiB. Total multipart body can be larger (default 20 MiB)
-/// but no single file may exceed this.
-const DEFAULT_MAX_FILE_SIZE: usize = 10 * 1024 * 1024;
 const JSON_FIELD_NAME: &str = "_json";
 
 /// Configurable limits for multipart uploads, injected via Axum extension.
@@ -70,7 +67,7 @@ pub async fn rpc_multipart_handler(
         .function_info(&function)
         .and_then(|info| info.max_upload_size_bytes)
         .unwrap_or(mp_config.max_body_size_bytes);
-    let max_file = max_total.min(DEFAULT_MAX_FILE_SIZE);
+    let max_file = max_total;
 
     let mut json_args: Option<serde_json::Value> = None;
     let mut uploads: HashMap<String, Upload> = HashMap::new();

--- a/crates/forge-runtime/src/gateway/server.rs
+++ b/crates/forge-runtime/src/gateway/server.rs
@@ -132,6 +132,7 @@ pub struct GatewayServer {
     token_ttl: forge_core::AuthTokenTtl,
     signals_collector: Option<crate::signals::SignalsCollector>,
     signals_anonymize_ip: bool,
+    custom_routes: Option<Router>,
 }
 
 impl GatewayServer {
@@ -157,6 +158,7 @@ impl GatewayServer {
             token_ttl,
             signals_collector: None,
             signals_anonymize_ip: false,
+            custom_routes: None,
         }
     }
 
@@ -189,6 +191,13 @@ impl GatewayServer {
     /// When true, raw client IPs are not stored in event records.
     pub fn with_signals_anonymize_ip(mut self, anonymize: bool) -> Self {
         self.signals_anonymize_ip = anonymize;
+        self
+    }
+
+    /// Set additional routes that receive the full middleware stack
+    /// (auth, CORS, tracing, concurrency limits, timeouts).
+    pub fn with_custom_routes(mut self, router: Router) -> Self {
+        self.custom_routes = Some(router);
         self
     }
 
@@ -433,6 +442,10 @@ impl GatewayServer {
             .merge(sse_router)
             .merge(mcp_router)
             .merge(signals_router);
+
+        if let Some(custom) = &self.custom_routes {
+            main_router = main_router.merge(custom.clone());
+        }
 
         // Build middleware stack
         let service_builder = ServiceBuilder::new()

--- a/crates/forge-runtime/src/gateway/server.rs
+++ b/crates/forge-runtime/src/gateway/server.rs
@@ -42,6 +42,7 @@ use crate::realtime::{Reactor, ReactorConfig};
 
 const DEFAULT_MAX_JSON_BODY_SIZE: usize = 1024 * 1024;
 const DEFAULT_MAX_MULTIPART_BODY_SIZE: usize = 20 * 1024 * 1024;
+const DEFAULT_MAX_FILE_SIZE: usize = 10 * 1024 * 1024;
 const MAX_MULTIPART_CONCURRENCY: usize = 32;
 /// Fallback for visitor ID hashing when no JWT secret is configured (dev only).
 const DEFAULT_SIGNAL_SECRET: &str = "forge-default-signal-secret";
@@ -73,6 +74,9 @@ pub struct GatewayConfig {
     pub project_name: String,
     /// Maximum body size in bytes for uploads. Defaults to 20 MB.
     pub max_body_size_bytes: usize,
+    /// Default per-file cap in bytes for multipart uploads. Applies when
+    /// a mutation does not declare its own `max_size`. Defaults to 10 MB.
+    pub max_file_size_bytes: usize,
 }
 
 impl Default for GatewayConfig {
@@ -90,6 +94,7 @@ impl Default for GatewayConfig {
             token_ttl: forge_core::AuthTokenTtl::default(),
             project_name: "forge-app".to_string(),
             max_body_size_bytes: DEFAULT_MAX_MULTIPART_BODY_SIZE,
+            max_file_size_bytes: DEFAULT_MAX_FILE_SIZE,
         }
     }
 }
@@ -361,6 +366,7 @@ impl GatewayServer {
         let layer_limit = self.config.max_body_size_bytes.max(max_per_mutation);
         let mp_config = MultipartConfig {
             max_body_size_bytes: self.config.max_body_size_bytes,
+            max_file_size_bytes: self.config.max_file_size_bytes,
         };
         let multipart_router = Router::new()
             .route("/rpc/{function}/upload", post(rpc_multipart_handler))

--- a/crates/forge/src/runtime.rs
+++ b/crates/forge/src/runtime.rs
@@ -107,8 +107,10 @@ pub struct Forge {
     extra_migrations: Vec<Migration>,
     /// Optional frontend handler for embedded SPA.
     frontend_handler: Option<FrontendHandler>,
-    /// Custom axum routes merged into the top-level router.
+    /// Custom axum routes that receive the full gateway middleware stack.
     custom_routes: Option<Router>,
+    /// Factory that produces custom routes after the pool is available.
+    custom_routes_factory: Option<Box<dyn FnOnce(sqlx::PgPool) -> Router + Send + Sync>>,
 }
 
 impl Forge {
@@ -596,6 +598,21 @@ impl Forge {
                 tracing::info!("Signals enabled (analytics + diagnostics)");
             }
 
+            // Resolve custom routes (static + factory) and pass to the gateway
+            // so they sit inside the middleware stack.
+            let mut resolved_custom = self.custom_routes.take();
+            if let Some(factory) = self.custom_routes_factory.take() {
+                let factory_router = factory(pool.clone());
+                resolved_custom = Some(match resolved_custom {
+                    Some(existing) => existing.merge(factory_router),
+                    None => factory_router,
+                });
+            }
+            if let Some(custom) = resolved_custom {
+                gateway = gateway.with_custom_routes(custom);
+                tracing::debug!("Custom routes merged into gateway middleware stack");
+            }
+
             // Start the reactor for real-time updates
             let reactor = gateway.reactor();
             if let Err(e) = reactor.start().await {
@@ -744,12 +761,6 @@ impl Forge {
                 }
             }
 
-            // Merge custom routes before frontend fallback so they take precedence
-            if let Some(custom) = self.custom_routes.take() {
-                router = router.merge(custom);
-                tracing::debug!("Custom routes merged");
-            }
-
             // Add frontend handler as fallback if configured
             if let Some(handler) = self.frontend_handler {
                 use axum::routing::get;
@@ -871,6 +882,7 @@ pub struct ForgeBuilder {
     extra_migrations: Vec<Migration>,
     frontend_handler: Option<FrontendHandler>,
     custom_routes: Option<Router>,
+    custom_routes_factory: Option<Box<dyn FnOnce(sqlx::PgPool) -> Router + Send + Sync>>,
 }
 
 impl ForgeBuilder {
@@ -889,6 +901,7 @@ impl ForgeBuilder {
             extra_migrations: Vec::new(),
             frontend_handler: None,
             custom_routes: None,
+            custom_routes_factory: None,
         }
     }
 
@@ -922,20 +935,42 @@ impl ForgeBuilder {
 
     /// Add custom axum routes to the server.
     ///
-    /// Routes are merged at the top level, outside `/_api`, giving full
-    /// control over headers, extractors, and response types. Avoid paths
-    /// starting with `/_api` as they conflict with internal routes.
+    /// Routes are merged inside the gateway's `/_api` router and receive
+    /// the full middleware stack (auth, CORS, tracing, concurrency limits,
+    /// timeouts) automatically. Avoid paths that conflict with built-in
+    /// routes like `/health`, `/rpc/*`, or `/webhooks/*`.
     ///
     /// ```ignore
     /// use axum::{Router, routing::get};
     ///
     /// let routes = Router::new()
-    ///     .route("/custom/health", get(|| async { "ok" }));
+    ///     .route("/export/data", get(|| async { "ok" }));
     ///
     /// builder.custom_routes(routes);
     /// ```
     pub fn custom_routes(mut self, router: Router) -> Self {
         self.custom_routes = Some(router);
+        self
+    }
+
+    /// Like [`custom_routes`](Self::custom_routes) but accepts a factory
+    /// that receives Forge's managed `PgPool` (resolved during `run()`).
+    ///
+    /// ```ignore
+    /// use axum::{Router, routing::get, extract::State};
+    /// use std::sync::Arc;
+    ///
+    /// builder.custom_routes_with(|pool| {
+    ///     Router::new()
+    ///         .route("/export/csv", get(my_handler))
+    ///         .with_state(Arc::new(pool))
+    /// });
+    /// ```
+    pub fn custom_routes_with<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(sqlx::PgPool) -> Router + Send + Sync + 'static,
+    {
+        self.custom_routes_factory = Some(Box::new(f));
         self
     }
 
@@ -1087,6 +1122,7 @@ impl ForgeBuilder {
             extra_migrations: self.extra_migrations,
             frontend_handler: self.frontend_handler,
             custom_routes: self.custom_routes,
+            custom_routes_factory: self.custom_routes_factory,
         })
     }
 }

--- a/crates/forge/src/runtime.rs
+++ b/crates/forge/src/runtime.rs
@@ -107,9 +107,10 @@ pub struct Forge {
     extra_migrations: Vec<Migration>,
     /// Optional frontend handler for embedded SPA.
     frontend_handler: Option<FrontendHandler>,
-    /// Custom axum routes that receive the full gateway middleware stack.
-    custom_routes: Option<Router>,
-    /// Factory that produces custom routes after the pool is available.
+    /// Factory that produces custom axum routes once the pool is available.
+    /// The returned router is merged into the gateway's `/_api` router, so
+    /// the full middleware stack (auth, CORS, tracing, concurrency, timeouts)
+    /// applies automatically.
     custom_routes_factory: Option<Box<dyn FnOnce(sqlx::PgPool) -> Router + Send + Sync>>,
 }
 
@@ -555,6 +556,7 @@ impl Forge {
                 mcp: self.config.mcp.clone(),
                 quiet_routes: self.config.gateway.quiet_routes.clone(),
                 max_body_size_bytes: self.config.gateway.max_body_size_bytes()?,
+                max_file_size_bytes: self.config.gateway.max_file_size_bytes()?,
                 token_ttl: forge_core::AuthTokenTtl {
                     access_token_secs: self.config.auth.access_token_ttl_secs(),
                     refresh_token_days: self.config.auth.refresh_token_ttl_days(),
@@ -598,18 +600,8 @@ impl Forge {
                 tracing::info!("Signals enabled (analytics + diagnostics)");
             }
 
-            // Resolve custom routes (static + factory) and pass to the gateway
-            // so they sit inside the middleware stack.
-            let mut resolved_custom = self.custom_routes.take();
             if let Some(factory) = self.custom_routes_factory.take() {
-                let factory_router = factory(pool.clone());
-                resolved_custom = Some(match resolved_custom {
-                    Some(existing) => existing.merge(factory_router),
-                    None => factory_router,
-                });
-            }
-            if let Some(custom) = resolved_custom {
-                gateway = gateway.with_custom_routes(custom);
+                gateway = gateway.with_custom_routes(factory(pool.clone()));
                 tracing::debug!("Custom routes merged into gateway middleware stack");
             }
 
@@ -881,7 +873,6 @@ pub struct ForgeBuilder {
     migrations_dir: PathBuf,
     extra_migrations: Vec<Migration>,
     frontend_handler: Option<FrontendHandler>,
-    custom_routes: Option<Router>,
     custom_routes_factory: Option<Box<dyn FnOnce(sqlx::PgPool) -> Router + Send + Sync>>,
 }
 
@@ -900,7 +891,6 @@ impl ForgeBuilder {
             migrations_dir: PathBuf::from("migrations"),
             extra_migrations: Vec::new(),
             frontend_handler: None,
-            custom_routes: None,
             custom_routes_factory: None,
         }
     }
@@ -933,40 +923,38 @@ impl ForgeBuilder {
         self
     }
 
-    /// Add custom axum routes to the server.
+    /// Register custom axum routes built from Forge's managed `PgPool`.
     ///
-    /// Routes are merged inside the gateway's `/_api` router and receive
-    /// the full middleware stack (auth, CORS, tracing, concurrency limits,
-    /// timeouts) automatically. Avoid paths that conflict with built-in
-    /// routes like `/health`, `/rpc/*`, or `/webhooks/*`.
+    /// The factory runs once during `run()`, after the database pool is
+    /// connected. The returned router is merged into the gateway's `/_api`
+    /// namespace, so every route receives the full middleware stack: auth
+    /// (JWT), CORS, tracing, concurrency limits, and timeouts.
+    ///
+    /// Route paths are relative to `/_api`. Registering `/export/csv`
+    /// exposes `GET /_api/export/csv`. Avoid paths that collide with
+    /// built-ins under `/_api`: `/health`, `/ready`, `/rpc`, `/rpc/*`,
+    /// `/events`, `/subscribe`, `/unsubscribe`, `/subscribe-job`,
+    /// `/subscribe-workflow`, `/signal/*`, `/mcp`, and `/oauth/*`.
+    ///
+    /// If your handlers don't need the pool, ignore the argument:
     ///
     /// ```ignore
-    /// use axum::{Router, routing::get};
-    ///
-    /// let routes = Router::new()
-    ///     .route("/export/data", get(|| async { "ok" }));
-    ///
-    /// builder.custom_routes(routes);
+    /// builder.custom_routes(|_| Router::new().route("/healthz", get(|| async { "ok" })));
     /// ```
-    pub fn custom_routes(mut self, router: Router) -> Self {
-        self.custom_routes = Some(router);
-        self
-    }
-
-    /// Like [`custom_routes`](Self::custom_routes) but accepts a factory
-    /// that receives Forge's managed `PgPool` (resolved during `run()`).
+    ///
+    /// With pool access:
     ///
     /// ```ignore
     /// use axum::{Router, routing::get, extract::State};
     /// use std::sync::Arc;
     ///
-    /// builder.custom_routes_with(|pool| {
+    /// builder.custom_routes(|pool| {
     ///     Router::new()
-    ///         .route("/export/csv", get(my_handler))
+    ///         .route("/export/csv", get(export_handler))
     ///         .with_state(Arc::new(pool))
     /// });
     /// ```
-    pub fn custom_routes_with<F>(mut self, f: F) -> Self
+    pub fn custom_routes<F>(mut self, f: F) -> Self
     where
         F: FnOnce(sqlx::PgPool) -> Router + Send + Sync + 'static,
     {
@@ -1121,7 +1109,6 @@ impl ForgeBuilder {
             migrations_dir: self.migrations_dir,
             extra_migrations: self.extra_migrations,
             frontend_handler: self.frontend_handler,
-            custom_routes: self.custom_routes,
             custom_routes_factory: self.custom_routes_factory,
         })
     }

--- a/docs/docs/build/custom-handlers.mdx
+++ b/docs/docs/build/custom-handlers.mdx
@@ -1,16 +1,16 @@
 # Custom Handlers
 
-Add raw axum routes when you need full control over HTTP handling while still receiving Forge's middleware stack.
+Add raw axum routes when you need full control over HTTP handling while still inheriting Forge's middleware stack.
 
 ## The Code
 
-The recommended pattern uses `custom_routes_with`, which gives your routes access to Forge's managed `PgPool` and the full middleware stack (auth, CORS, tracing, concurrency limits, timeouts):
+`custom_routes` takes a factory closure. Forge calls it once during `run()` and hands you the managed `PgPool`, so you can build a `Router` that talks to the database. The returned router is merged inside the gateway's `/_api` namespace, which means it automatically picks up auth, CORS, tracing, concurrency limits, and timeouts.
 
 ```rust
 use std::sync::Arc;
 use forge::prelude::*;
 use forge::prelude::axum::{
-    Router, Json,
+    Router,
     Extension,
     extract::{Query, State},
     http::StatusCode,
@@ -23,12 +23,11 @@ async fn csv_export(
     Extension(auth): Extension<AuthContext>,
     Query(params): Query<ExportParams>,
 ) -> impl IntoResponse {
-    if !auth.is_authenticated() {
-        return (StatusCode::UNAUTHORIZED, "Authentication required").into_response();
-    }
-    // auth.user_id() is available — the middleware already parsed the JWT
-    let user_id = auth.user_id().unwrap();
-    // ... query the pool, stream CSV, etc.
+    let user_id = match auth.user_id() {
+        Some(id) => id,
+        None => return (StatusCode::UNAUTHORIZED, "Authentication required").into_response(),
+    };
+    // ... query `pool`, stream CSV for `user_id`, etc.
     (StatusCode::OK, "ok").into_response()
 }
 
@@ -38,7 +37,7 @@ async fn main() -> Result<()> {
 
     Forge::builder()
         .config(config)
-        .custom_routes_with(|pool| {
+        .custom_routes(|pool| {
             Router::new()
                 .route("/export/csv", get(csv_export))
                 .with_state(Arc::new(pool))
@@ -49,15 +48,14 @@ async fn main() -> Result<()> {
 }
 ```
 
-If your routes don't need the database pool, use `custom_routes` instead:
+Route paths are relative to `/_api`. The `GET /export/csv` handler above is reachable at `GET /_api/export/csv`.
+
+If your handlers don't need the pool, ignore the argument:
 
 ```rust
-let custom = Router::new()
-    .route("/healthz", get(health_check));
-
 Forge::builder()
     .config(config)
-    .custom_routes(custom)
+    .custom_routes(|_| Router::new().route("/healthz", get(|| async { "ok" })))
     .build()?
     .run()
     .await
@@ -65,9 +63,7 @@ Forge::builder()
 
 ## What Happens
 
-Custom routes are merged inside the gateway's `/_api` router and receive the full middleware stack automatically: auth, CORS, tracing, concurrency limits, and timeouts. Your handlers can extract `Extension<AuthContext>` to access the authenticated user without any manual JWT parsing.
-
-The `custom_routes_with(|pool| ...)` variant accepts a factory closure that receives Forge's managed `PgPool` once the database connection is established during `run()`. This is the intended way to give custom handlers database access, since the pool isn't available at builder time.
+The factory runs after the pool is connected and before the gateway starts. Forge merges your router into the gateway's main router, then wraps the combined router with the middleware stack, so custom handlers get the same auth, tracing, and rate limiting as built-in endpoints. Use `Extension<AuthContext>` to read the authenticated user without parsing JWTs by hand.
 
 ## When to Use
 
@@ -76,34 +72,24 @@ The `custom_routes_with(|pool| ...)` variant accepts a factory closure that rece
 | Standard queries and mutations | `#[forge::query]`, `#[forge::mutation]` |
 | Webhook endpoints with signatures | `#[forge::webhook]` |
 | AI tool exposure | `#[forge::mcp_tool]` |
-| Streaming responses, file downloads, custom content types | `custom_routes_with()` |
-| Third-party integrations needing exact HTTP semantics | `custom_routes()` |
+| Streaming responses, file downloads, custom content types | `custom_routes` |
+| Third-party integrations needing exact HTTP semantics | `custom_routes` |
 
 ## Route Conflicts
 
-Custom routes share the `/_api` namespace with built-in Forge endpoints. Avoid paths that conflict with `/health`, `/ready`, `/rpc/*`, `/webhooks/*`, `/events`, or `/mcp/*`. Conflicting paths cause a runtime panic.
+Custom routes share the `/_api` namespace with built-in Forge endpoints. Registering a path that already belongs to Forge panics at startup. Avoid:
 
-## Database Access
-
-Use `custom_routes_with` to receive the pool as a closure argument, then pass it to your router via axum's `State`:
-
-```rust
-Forge::builder()
-    .custom_routes_with(|pool| {
-        Router::new()
-            .route("/export/csv", get(csv_export))
-            .with_state(Arc::new(pool))
-    })
-    .build()?
-    .run()
-    .await
-```
-
-Your handler extracts it with `State(pool): State<Arc<sqlx::PgPool>>`.
+- `/health`, `/ready`
+- `/rpc`, `/rpc/batch`, `/rpc/{function}`, `/rpc/{function}/upload`
+- `/events`, `/subscribe`, `/unsubscribe`, `/subscribe-job`, `/subscribe-workflow`
+- `/signal/event`, `/signal/view`, `/signal/user`, `/signal/report`
+- `/webhooks/*`
+- `/mcp` (if MCP is enabled)
+- `/oauth/authorize`, `/oauth/token`, `/oauth/register` (if MCP OAuth is enabled)
 
 ## Authentication
 
-The auth middleware runs before your handler. Extract the authenticated user with:
+The auth middleware runs before your handler. Unauthenticated requests still reach the handler with an unauthenticated `AuthContext`, so check before trusting it:
 
 ```rust
 async fn my_handler(
@@ -113,9 +99,7 @@ async fn my_handler(
         Some(id) => id,
         None => return (StatusCode::UNAUTHORIZED, "Not authenticated").into_response(),
     };
-    // user_id is available for authorization checks
+    // user_id available for authorization checks
     (StatusCode::OK, "ok").into_response()
 }
 ```
-
-Unauthenticated requests still reach your handler (with an unauthenticated `AuthContext`), so check `auth.is_authenticated()` or `auth.user_id()` if the endpoint requires login.

--- a/docs/docs/build/custom-handlers.mdx
+++ b/docs/docs/build/custom-handlers.mdx
@@ -1,58 +1,73 @@
 # Custom Handlers
 
-Add raw axum routes when you need full control over HTTP handling outside Forge's RPC system.
+Add raw axum routes when you need full control over HTTP handling while still receiving Forge's middleware stack.
 
 ## The Code
 
+The recommended pattern uses `custom_routes_with`, which gives your routes access to Forge's managed `PgPool` and the full middleware stack (auth, CORS, tracing, concurrency limits, timeouts):
+
 ```rust
+use std::sync::Arc;
 use forge::prelude::*;
 use forge::prelude::axum::{
     Router, Json,
-    extract::{Path, Query, State},
-    http::{HeaderMap, StatusCode},
+    Extension,
+    extract::{Query, State},
+    http::StatusCode,
     response::IntoResponse,
-    routing::{get, post},
+    routing::get,
 };
 
-async fn health_check() -> impl IntoResponse {
-    Json(serde_json::json!({ "status": "ok" }))
-}
-
-async fn proxy_webhook(
-    headers: HeaderMap,
-    body: axum::body::Bytes,
+async fn csv_export(
+    State(pool): State<Arc<sqlx::PgPool>>,
+    Extension(auth): Extension<AuthContext>,
+    Query(params): Query<ExportParams>,
 ) -> impl IntoResponse {
-    // Full access to headers, raw body, status codes
-    let signature = headers
-        .get("x-signature")
-        .and_then(|v| v.to_str().ok());
-
-    match signature {
-        Some(_sig) => (StatusCode::OK, "accepted"),
-        None => (StatusCode::UNAUTHORIZED, "missing signature"),
+    if !auth.is_authenticated() {
+        return (StatusCode::UNAUTHORIZED, "Authentication required").into_response();
     }
+    // auth.user_id() is available — the middleware already parsed the JWT
+    let user_id = auth.user_id().unwrap();
+    // ... query the pool, stream CSV, etc.
+    (StatusCode::OK, "ok").into_response()
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let config = ForgeConfig::from_file("forge.toml")?;
 
-    let custom = Router::new()
-        .route("/healthz", get(health_check))
-        .route("/hooks/external", post(proxy_webhook));
-
     Forge::builder()
         .config(config)
-        .custom_routes(custom)
+        .custom_routes_with(|pool| {
+            Router::new()
+                .route("/export/csv", get(csv_export))
+                .with_state(Arc::new(pool))
+        })
         .build()?
         .run()
         .await
 }
 ```
 
+If your routes don't need the database pool, use `custom_routes` instead:
+
+```rust
+let custom = Router::new()
+    .route("/healthz", get(health_check));
+
+Forge::builder()
+    .config(config)
+    .custom_routes(custom)
+    .build()?
+    .run()
+    .await
+```
+
 ## What Happens
 
-Custom routes are merged at the top level of the HTTP server, outside the `/_api` namespace. They run without Forge's auth middleware, rate limiting, or tracing. You handle everything yourself.
+Custom routes are merged inside the gateway's `/_api` router and receive the full middleware stack automatically: auth, CORS, tracing, concurrency limits, and timeouts. Your handlers can extract `Extension<AuthContext>` to access the authenticated user without any manual JWT parsing.
+
+The `custom_routes_with(|pool| ...)` variant accepts a factory closure that receives Forge's managed `PgPool` once the database connection is established during `run()`. This is the intended way to give custom handlers database access, since the pool isn't available at builder time.
 
 ## When to Use
 
@@ -61,37 +76,46 @@ Custom routes are merged at the top level of the HTTP server, outside the `/_api
 | Standard queries and mutations | `#[forge::query]`, `#[forge::mutation]` |
 | Webhook endpoints with signatures | `#[forge::webhook]` |
 | AI tool exposure | `#[forge::mcp_tool]` |
-| Custom health checks, metrics, proxies | `custom_routes()` |
+| Streaming responses, file downloads, custom content types | `custom_routes_with()` |
 | Third-party integrations needing exact HTTP semantics | `custom_routes()` |
 
 ## Route Conflicts
 
-Custom routes must not start with `/_api`. That prefix is reserved for Forge internal endpoints (RPC, SSE, MCP, webhooks). Conflicting paths cause a runtime panic.
+Custom routes share the `/_api` namespace with built-in Forge endpoints. Avoid paths that conflict with `/health`, `/ready`, `/rpc/*`, `/webhooks/*`, `/events`, or `/mcp/*`. Conflicting paths cause a runtime panic.
 
-## Shared State
+## Database Access
 
-Pass shared state to custom handlers using axum's `State` extractor:
+Use `custom_routes_with` to receive the pool as a closure argument, then pass it to your router via axum's `State`:
 
 ```rust
-use std::sync::Arc;
-
-struct AppState {
-    pool: sqlx::PgPool,
-}
-
-async fn custom_handler(
-    State(state): State<Arc<AppState>>,
-) -> impl IntoResponse {
-    // Use state.pool for database access
-    Json(serde_json::json!({ "ok": true }))
-}
-
-let state = Arc::new(AppState { pool: pool.clone() });
-let custom = Router::new()
-    .route("/custom", get(custom_handler))
-    .with_state(state);
-
-builder.custom_routes(custom);
+Forge::builder()
+    .custom_routes_with(|pool| {
+        Router::new()
+            .route("/export/csv", get(csv_export))
+            .with_state(Arc::new(pool))
+    })
+    .build()?
+    .run()
+    .await
 ```
 
-Since custom routes bypass Forge middleware, you must handle authentication, logging, and error responses yourself.
+Your handler extracts it with `State(pool): State<Arc<sqlx::PgPool>>`.
+
+## Authentication
+
+The auth middleware runs before your handler. Extract the authenticated user with:
+
+```rust
+async fn my_handler(
+    Extension(auth): Extension<AuthContext>,
+) -> impl IntoResponse {
+    let user_id = match auth.user_id() {
+        Some(id) => id,
+        None => return (StatusCode::UNAUTHORIZED, "Not authenticated").into_response(),
+    };
+    // user_id is available for authorization checks
+    (StatusCode::OK, "ok").into_response()
+}
+```
+
+Unauthenticated requests still reach your handler (with an unauthenticated `AuthContext`), so check `auth.is_authenticated()` or `auth.user_id()` if the endpoint requires login.

--- a/docs/docs/ship/configuration.mdx
+++ b/docs/docs/ship/configuration.mdx
@@ -133,17 +133,19 @@ Without pool isolation configured, everything shares the primary pool. With it c
 | `cors_origins`         | string[] | `[]`                              | Allowed CORS origins (use `["*"]` for any)     |
 | `quiet_routes`         | string[] | `[]`                              | Routes excluded from traces, metrics, and logs |
 | `sse_max_sessions`     | usize    | `10000`                           | Maximum concurrent SSE sessions                |
-| `max_body_size`        | string   | `"20mb"`                          | Global upload size limit. Supports `b`, `kb`, `mb`, `gb` suffixes. Per-mutation `max_size` overrides this. |
+| `max_body_size`        | string   | `"20mb"`                          | Total multipart body cap. Supports `b`, `kb`, `mb`, `gb` suffixes. Per-mutation `max_size` overrides this. |
+| `max_file_size`        | string   | `"10mb"`                          | Per-file cap applied when a mutation does not declare its own `max_size`. Must be ≤ `max_body_size`. |
 
 #### Request Body Limits
 
-| Payload        | Default | Configurable                                              |
-| -------------- | ------- | --------------------------------------------------------- |
-| JSON body      | 1 MiB   | Not configurable                                          |
-| Multipart total| 20 MiB  | `gateway.max_body_size` in forge.toml                     |
-| Per mutation   | -       | `#[forge::mutation(max_size = "200mb")]` per handler      |
+| Payload         | Default | Configurable                                              |
+| --------------- | ------- | --------------------------------------------------------- |
+| JSON body       | 1 MiB   | Not configurable                                          |
+| Multipart total | 20 MiB  | `gateway.max_body_size` in forge.toml                     |
+| Per file        | 10 MiB  | `gateway.max_file_size` in forge.toml                     |
+| Per mutation    | -       | `#[forge::mutation(max_size = "200mb")]` per handler      |
 
-The per-mutation `max_size` attribute overrides the global `max_body_size` for that specific mutation. Other fixed limits: 20 upload fields per request, 32 concurrent in-flight uploads.
+When a mutation declares `max_size`, that value becomes both the total and per-file limit for that endpoint — treat it as an explicit opt-in for large single files. Without an override, the total falls back to `max_body_size` and any single file is capped by `max_file_size`. Other fixed limits: 20 upload fields per request, 32 concurrent in-flight uploads.
 
 ### [function]
 

--- a/docs/skills/forge-idiomatic-engineer/references/api.md
+++ b/docs/skills/forge-idiomatic-engineer/references/api.md
@@ -167,6 +167,10 @@ jwt_secret = "${JWT_SECRET}"
 url = "${DATABASE_URL}"
 max_connections = 20          # default pool size
 
+[gateway]
+max_body_size = "20mb"        # total multipart body cap (default)
+max_file_size = "10mb"        # per-file cap when mutation has no max_size (default)
+
 [worker]
 concurrency = 10              # parallel job slots per node
 
@@ -178,6 +182,28 @@ otlp_endpoint = "http://localhost:4318"
 enabled = true                # default; set false to disable analytics
 anonymize_ip = false
 ```
+
+### Upload Size Limits
+
+`gateway.max_body_size` caps the total HTTP body. `gateway.max_file_size` caps any single file when the target mutation does not declare its own `max_size`. When a mutation sets `max_size = "200mb"`, that value becomes both the total and per-file limit for that endpoint (explicit opt-in). Validation requires `max_file_size <= max_body_size`.
+
+## Custom Axum Routes
+
+`ForgeBuilder::custom_routes(|pool| Router)` registers additional HTTP routes that inherit the gateway's middleware stack. The factory runs once during `run()` after the pool is connected.
+
+```rust
+builder.custom_routes(|pool| {
+    Router::new()
+        .route("/export/csv", get(csv_export))
+        .with_state(Arc::new(pool))
+})
+```
+
+- Factory receives `sqlx::PgPool`. Ignore it with `|_|` if not needed.
+- Returned router is merged into the gateway's `/_api` namespace, so `/export/csv` is reachable at `/_api/export/csv`.
+- Full middleware applies automatically: JWT auth, CORS, tracing, concurrency limits, request timeouts.
+- Handlers read `Extension<AuthContext>` to access the authenticated user. Unauthenticated requests still arrive with an unauthenticated context — check `auth.user_id()` if login is required.
+- Avoid paths that conflict with built-ins: `/health`, `/ready`, `/rpc`, `/rpc/*`, `/events`, `/subscribe`, `/unsubscribe`, `/subscribe-job`, `/subscribe-workflow`, `/signal/*`, `/webhooks/*`, `/mcp`, `/oauth/*`. Conflicts panic at startup.
 
 ### Pool Routing
 

--- a/docs/skills/forge-idiomatic-engineer/references/patterns.md
+++ b/docs/skills/forge-idiomatic-engineer/references/patterns.md
@@ -109,6 +109,29 @@ Always exchange OAuth codes on the server to prevent exposing provider secrets o
 - **Read-Only vs Destructive**: Annotate tools with their intended behavior to help AI models select the correct tool.
 - **Authorization**: MCP tools require authentication by default. Use `require_role` to restrict access to specific agents.
 
+### Custom Axum Routes
+Reach for `ForgeBuilder::custom_routes` when a handler cannot fit the RPC/query/mutation shape (streaming responses, non-JSON content types, file downloads that aren't `Upload`). Everything else should stay in a `#[forge::query]` or `#[forge::mutation]` so it gets codegen bindings for free.
+
+```rust
+Forge::builder()
+    .config(config)
+    .custom_routes(|pool| {
+        Router::new()
+            .route("/export/csv", get(csv_export))
+            .with_state(Arc::new(pool))
+    })
+    .auto_register()
+    .build()?
+    .run()
+    .await
+```
+
+- The factory receives Forge's managed `PgPool`. Use `|_|` if you don't need it.
+- Route paths mount under `/_api`. A route declared as `/export/csv` is served at `/_api/export/csv`.
+- JWT auth, CORS, tracing, concurrency limits, and timeouts apply automatically — do not re-implement them.
+- Read the authenticated user with `Extension<AuthContext>`. Unauthenticated requests still reach the handler, so guard with `match auth.user_id()` (never `.unwrap()`).
+- Do not collide with built-in paths under `/_api`: `/health`, `/ready`, `/rpc`, `/rpc/*`, `/events`, `/subscribe*`, `/signal/*`, `/webhooks/*`, `/mcp`, `/oauth/*`.
+
 ## 4. Testing
 
 All tests use `#[tokio::test]`. Unit tests live inline in `#[cfg(test)] mod tests {}`. DB integration tests are gated behind the `testcontainers` feature flag.

--- a/docs/skills/forge-idiomatic-engineer/references/pitfalls.md
+++ b/docs/skills/forge-idiomatic-engineer/references/pitfalls.md
@@ -76,7 +76,14 @@ sqlx::query_as!(User, "...", id).fetch_one(&mut conn).await
 - **Use anonymous clients for token refresh**: Including expired tokens in headers during a refresh call will cause the request to be rejected.
 - **Reserve `Forbidden` for permission violations**: Do not use `Forbidden` errors for business logic (e.g., "account needs upgrade"), as this triggers the global `onAuthError` handler and logs the user out.
 
-## 8. Resilience and Hygiene
+## 8. Custom Routes and Uploads
+
+- **Custom routes live under `/_api`**: `ForgeBuilder::custom_routes(|pool| ...)` merges into the gateway router. A declared `/export/csv` resolves to `/_api/export/csv`. Document the full path to clients — writing the raw declaration is a common off-by-prefix bug.
+- **Never `.unwrap()` `AuthContext`**: The auth middleware still forwards unauthenticated requests to your handler. `auth.user_id().unwrap()` panics and hits the workspace `clippy::unwrap_used` deny. Use `match auth.user_id()` with an early 401 return.
+- **Don't re-implement auth in custom handlers**: Middleware already parses the JWT and injects `Extension<AuthContext>`. Do not reach for headers or parse tokens yourself.
+- **Per-file upload cap is independent of total body**: `gateway.max_body_size` caps the full multipart body, but individual files are capped by `gateway.max_file_size` (defaults to `"10mb"`). A mutation that legitimately accepts a big file must declare `max_size = "…"`; that value becomes both the total and per-file limit for that endpoint.
+
+## 9. Resilience and Hygiene
 
 - **Consistently check for ID existence**: See [Resilience Patterns](./resilience.md#2-database-and-data-integrity).
 - **Include context in error messages**: Always include relevant IDs and context in your error messages to make debugging easier for both developers and users.


### PR DESCRIPTION
# Preface

I sometimes need routes that aren't fully supported by the forge response shapes. I talked with Supiri about an original change I made called "authenticated_routes" that used a similar builder pattern. They helpfully suggested that we move the place that `custom_routes` merge into the main_router, which is a much better solution.

The second change is motivated by my need to support large uploads in certain endpoints but not others. If this needs to be a separate PR we can split it up.

# Core

## Summary

Two changes in this PR:

1. **Custom routes middleware** — Moves the `custom_routes` merge point into the gateway's middleware stack so custom routes automatically receive auth, CORS, tracing, concurrency limits, and timeouts. Also adds `custom_routes_with(|pool| ...)` for pool access.

2. **Fix per-file upload cap ignoring `max_size`** — Removes a hardcoded 10 MiB per-file limit that silently clamped individual file uploads below the configured `max_size` or `max_body_size`.

---

## 1. Apply middleware stack to custom routes

### Changes

- **`crates/forge-runtime/src/gateway/server.rs`** — Add `custom_routes` field to `GatewayServer`, `with_custom_routes()` setter, and merge into `main_router` before the `ServiceBuilder` middleware layers are applied.
- **`crates/forge/src/runtime.rs`** — Add `custom_routes_factory` field and `custom_routes_with()` builder method. Resolve the factory after the pool is connected in `run()`, pass merged routes to `gateway.with_custom_routes()`. Remove the old root-level `router.merge(custom)` that bypassed middleware.

### Motivation

Custom routes merged at the top level don't get any of the gateway middleware (auth, CORS, tracing, etc.), which makes them unusable for real API endpoints that need authentication. Rather than adding a second concept (`authenticated_routes`), this moves the existing merge point so the middleware applies automatically.

The `_with(|pool| ...)` variant is necessary because the database pool isn't available when the builder is constructed — it's created during `run()`.

This keeps a single `custom_routes` concept instead of requiring a separate `authenticated_routes` API — one merge point, one set of docs, one mental model.

---

## 2. Fix per-file upload cap ignoring max_size configuration

### Changes

- **`crates/forge-runtime/src/gateway/multipart.rs`** — Remove `DEFAULT_MAX_FILE_SIZE` (hardcoded 10 MiB) and set `max_file = max_total` so the per-file limit equals the resolved total limit.

### Motivation

The multipart handler had a hardcoded `DEFAULT_MAX_FILE_SIZE` of 10 MiB that was applied via `max_file = max_total.min(DEFAULT_MAX_FILE_SIZE)`. This meant that even when a mutation declared `max_size = "200mb"` or `forge.toml` set `max_body_size = "100mb"`, no single file could exceed 10 MiB. The total payload limit was respected, but the per-file limit silently clamped to 10 MiB.

Since a single file can legitimately be the entire payload, the per-file limit should equal the total limit. The total limit (`max_total`) already provides the safety bound.

---

## Test plan

- [x] `cargo check` passes across the workspace
- [x] `cargo test --workspace` — all existing tests pass
- [x] Manual: register a custom route via `custom_routes_with`, confirm it receives auth headers and rejects unauthenticated requests
- [x] Manual: upload a file larger than 10 MB to a mutation with `max_size = "200mb"`, confirm it succeeds