### PR TITLE
Split CI into PR smoke + workspace integration via reusable workflow

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -1,0 +1,152 @@
+name: ChatOps
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  parse:
+    name: Parse command
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/')
+    runs-on: ubuntu-latest
+    outputs:
+      cmd: ${{ steps.parse.outputs.cmd }}
+      matrix: ${{ steps.parse.outputs.matrix }}
+      pr_sha: ${{ steps.pr.outputs.sha }}
+      pr_ref: ${{ steps.pr.outputs.ref }}
+    steps:
+      - name: Gate on author association
+        env:
+          ASSOC: ${{ github.event.comment.author_association }}
+        run: |
+          case "$ASSOC" in
+            OWNER|MEMBER|COLLABORATOR) ;;
+            *) echo "::error::author_association=$ASSOC not allowed"; exit 1 ;;
+          esac
+
+      - name: Parse
+        id: parse
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          first_line=$(printf '%s' "$BODY" | head -n1)
+          cmd=$(printf '%s' "$first_line" | awk '{print $1}')
+          arg=$(printf '%s' "$first_line" | awk '{print $2}')
+
+          echo "cmd=$cmd" >> "$GITHUB_OUTPUT"
+
+          all='["with-svelte/minimal","with-svelte/demo","with-svelte/realtime-todo-list","with-dioxus/minimal","with-dioxus/demo","with-dioxus/realtime-todo-list"]'
+
+          case "$cmd" in
+            /test-template)
+              if [ -z "$arg" ] || [ "$arg" = "all" ]; then
+                matrix="$all"
+              elif printf '%s' "$arg" | grep -Eq '^with-(svelte|dioxus)/(minimal|demo|realtime-todo-list)$'; then
+                matrix="[\"$arg\"]"
+              else
+                echo "::error::invalid template '$arg' — expected with-(svelte|dioxus)/(minimal|demo|realtime-todo-list)"
+                exit 1
+              fi
+              echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+              ;;
+            /squash-merge)
+              ;;
+            *)
+              echo "::error::unknown command '$cmd' — supported: /test-template, /squash-merge"
+              exit 1
+              ;;
+          esac
+
+      - name: Resolve PR head
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('sha', pr.data.head.sha);
+            core.setOutput('ref', pr.data.head.ref);
+
+      - name: React to comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+  test-template:
+    needs: parse
+    if: needs.parse.outputs.cmd == '/test-template'
+    strategy:
+      fail-fast: false
+      matrix:
+        template: ${{ fromJSON(needs.parse.outputs.matrix) }}
+    uses: ./.github/workflows/template-smoke.yml
+    with:
+      template: ${{ matrix.template }}
+      ref: ${{ needs.parse.outputs.pr_sha }}
+      timeout-minutes: 30
+
+  squash-merge:
+    name: Enable auto squash-merge
+    needs: parse
+    if: needs.parse.outputs.cmd == '/squash-merge'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr merge "$PR" --auto --squash --delete-branch --repo "$REPO"
+
+      - name: Comment
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const result = '${{ job.status }}';
+            const emoji = result === 'success' ? '🟢' : '❌';
+            const body = result === 'success'
+              ? `${emoji} auto squash-merge armed — PR will merge once required checks pass`
+              : `${emoji} failed to enable auto-merge (check repo settings: auto-merge allowed + required checks on main)`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+  report:
+    name: Report result
+    needs: [parse, test-template]
+    if: always() && needs.parse.result == 'success' && needs.parse.outputs.cmd == '/test-template'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const result = '${{ needs.test-template.result }}';
+            const emoji = result === 'success' ? '✅' : result === 'cancelled' ? '🟡' : '❌';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `${emoji} \`/test-template\` ${result} — [run](${runUrl})`,
+            });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,24 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.gitignore'
+      - 'LICENSE*'
+      - '.github/ISSUE_TEMPLATE/**'
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.gitignore'
+      - 'LICENSE*'
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
@@ -12,46 +27,40 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   SQLX_OFFLINE: "true"
-  FORGE_TEST_ARTIFACT_DIR: /tmp/forge-test-artifacts
   CARGO_INCREMENTAL: "0"
+  FORGE_TEST_ARTIFACT_DIR: /tmp/forge-test-artifacts
 
 jobs:
-  fmt:
-    name: Format
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - run: cargo fmt --all --check
-
   validate:
     name: Validate
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
           cache-on-failure: true
-      - run: scripts/ci/create-env-stubs.sh
-      - run: cargo clippy --all-targets --all-features --workspace -- -D warnings
-      - run: cargo test --workspace
-      - run: cargo build -p forgex
-      - uses: actions/upload-artifact@v4
-        with:
-          name: forge-cli
-          path: target/debug/forge
-          retention-days: 1
 
-  example-integration:
-    name: Example Integration
+      - name: fmt
+        run: cargo fmt --all --check
+
+      - run: scripts/ci/create-env-stubs.sh
+
+      - name: clippy
+        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
+
+      - name: test
+        run: cargo test --workspace
+
+  workspace-integration:
+    name: Workspace integration
     needs: validate
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     services:
       postgres:
         image: postgres:18
@@ -78,10 +87,25 @@ jobs:
       - run: cargo test -p forge-svelte-demo-template --features testcontainers
       - run: cargo test -p todo --features testcontainers
 
-  template-smoke:
-    name: ${{ matrix.template }}
+  pr-smoke:
+    name: PR Smoke
     needs: validate
-    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        template:
+          - with-svelte/demo
+          - with-dioxus/demo
+    uses: ./.github/workflows/template-smoke.yml
+    with:
+      template: ${{ matrix.template }}
+      timeout-minutes: 20
+
+  integration:
+    name: Integration
+    needs: validate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:
@@ -92,27 +116,7 @@ jobs:
           - with-dioxus/minimal
           - with-dioxus/demo
           - with-dioxus/realtime-todo-list
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: template-build
-          workspaces: /tmp/test-project -> target
-      - uses: oven-sh/setup-bun@v2
-      - uses: actions/download-artifact@v4
-        with:
-          name: forge-cli
-          path: /tmp/forge-bin
-      - run: chmod +x /tmp/forge-bin/forge
-      - if: startsWith(matrix.template, 'with-dioxus/')
-        uses: cargo-bins/cargo-binstall@main
-      - if: startsWith(matrix.template, 'with-dioxus/')
-        run: cargo binstall dioxus-cli@0.7.5 --no-confirm
-      - run: scripts/ci/test-template.sh "${{ matrix.template }}" /tmp/forge-bin/forge "${{ github.workspace }}"
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: playwright-${{ strategy.job-index }}
-          path: /tmp/forge-test-artifacts/**
-          retention-days: 7
+    uses: ./.github/workflows/template-smoke.yml
+    with:
+      template: ${{ matrix.template }}
+      timeout-minutes: 20

--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -1,0 +1,68 @@
+name: Template Smoke
+
+on:
+  workflow_call:
+    inputs:
+      template:
+        description: Template path like with-svelte/demo
+        required: true
+        type: string
+      ref:
+        description: Git ref to check out (defaults to the calling workflow's ref)
+        required: false
+        type: string
+        default: ''
+      timeout-minutes:
+        required: false
+        type: number
+        default: 20
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  SQLX_OFFLINE: "true"
+  CARGO_INCREMENTAL: "0"
+  FORGE_TEST_ARTIFACT_DIR: /tmp/forge-test-artifacts
+
+concurrency:
+  group: smoke-${{ inputs.ref || github.ref }}-${{ inputs.template }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: ${{ inputs.template }}
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: template-build
+          workspaces: |
+            . -> target
+            /tmp/test-project -> target
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Build forge CLI
+        run: cargo build -p forgex
+
+      - if: startsWith(inputs.template, 'with-dioxus/')
+        uses: cargo-bins/cargo-binstall@main
+      - if: startsWith(inputs.template, 'with-dioxus/')
+        run: cargo binstall dioxus-cli@0.7.5 --no-confirm
+
+      - run: scripts/ci/test-template.sh "${{ inputs.template }}" target/debug/forge "${{ github.workspace }}"
+
+      - if: failure()
+        run: echo "ARTIFACT_SLUG=$(echo '${{ inputs.template }}' | tr '/' '-')" >> "$GITHUB_ENV"
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-${{ env.ARTIFACT_SLUG }}
+          path: /tmp/forge-test-artifacts/**
+          retention-days: 7

--- a/.github/workflows/template-smoke.yml
+++ b/.github/workflows/template-smoke.yml
@@ -43,9 +43,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: template-build
-          workspaces: |
-            . -> target
-            /tmp/test-project -> target
+          workspaces: . -> target
       - uses: oven-sh/setup-bun@v2
 
       - name: Build forge CLI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,11 +239,16 @@ LTO enabled, single codegen unit, symbols stripped.
 ## CI Pipeline
 
 `.github/workflows/ci.yml`:
-1. **validate**: fmt check -> clippy (warnings = errors) -> cargo test --workspace -> build CLI
-2. **example-integration** (needs validate): Postgres 18 service, `cargo test -p forge-svelte-demo-template --features testcontainers`, `cargo test -p todo --features testcontainers`
-3. **template-smoke** (needs validate, matrix of 6 templates): scaffold with `forge new` -> `forge check` -> start PG in Docker -> build backend -> run backend tests -> Playwright e2e
+1. **validate**: fmt check -> clippy (warnings = errors) -> cargo test --workspace (SQLX_OFFLINE)
+2. **workspace-integration** (needs validate, runs on PR + main): Postgres 18 service, `cargo test -p forge-svelte-demo-template --features testcontainers`, `cargo test -p todo --features testcontainers`
+3. **pr-smoke** (PR only, needs validate): matrix of `with-svelte/demo` + `with-dioxus/demo`, calls the reusable `template-smoke.yml` workflow
+4. **integration** (main push only, needs validate): matrix of all 6 templates, calls the reusable `template-smoke.yml` workflow
 
-Environment: `SQLX_OFFLINE=true`, `CARGO_TERM_COLOR=always`, `FORGE_TEST_ARTIFACT_DIR=/tmp/forge-test-artifacts`.
+`.github/workflows/template-smoke.yml` (reusable, `workflow_call`): inputs `template`, `ref` (optional), `timeout-minutes` (default 20). Steps: checkout at ref -> build forge CLI -> install dioxus-cli if dioxus template -> `scripts/ci/test-template.sh` (scaffold with `forge new`, patch deps to local workspace, `forge check`, install Playwright, `forge test`). Concurrency keyed on `(ref or github.ref) + template` so repeated runs on the same template cancel the older one. Uploads Playwright report on failure.
+
+`.github/workflows/chatops.yml`: triggered by PR comments. `/test-template [name|all]` runs the reusable workflow against PR head SHA (30 min timeout). `/squash-merge` arms auto-merge. Gated on `author_association` (OWNER/MEMBER/COLLABORATOR).
+
+Environment: `SQLX_OFFLINE=true`, `CARGO_TERM_COLOR=always`, `CARGO_INCREMENTAL=0`, `FORGE_TEST_ARTIFACT_DIR=/tmp/forge-test-artifacts`. Path-ignore filters skip CI entirely for docs, markdown, and LICENSE changes.
 
 ## Testing Examples (E2E)
 

--- a/scripts/ci/test-template.sh
+++ b/scripts/ci/test-template.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 TEMPLATE="$1"
-FORGE="$2"
+FORGE="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
 WORKSPACE="$3"
 shift 3
 PLAYWRIGHT_ARGS=("$@")


### PR DESCRIPTION
restructures CI so PRs actually smoke-test the templates. previously the template matrix only ran on main push, which meant codegen/macro regressions only surfaced after merge.

changes:
- extract `.github/workflows/template-smoke.yml` as a reusable `workflow_call` so ci.yml and chatops.yml share one source of truth
- ci.yml: `validate` unchanged. new `workspace-integration` job pulls the testcontainer tests out of the template shards (Postgres service, runs on PR + main). new `pr-smoke` runs the two demo templates on PRs. `integration` still runs the full 6-template matrix on main push only. 20min shard timeout across the board.
- chatops.yml: `/test-template` now calls the reusable workflow against PR head SHA (30min timeout). `/squash-merge` and the report comment are unchanged.
- AGENTS.md: CI Pipeline section refreshed to match.

one thing to watch: branch protection required-check names will shift to the reusable-workflow form (something like PR Smoke / with-svelte/demo / smoke). will update after first run once names are visible.